### PR TITLE
Upgrade SonarQube base image version on v4.5.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sonarqube:4.5.4
+FROM sonarqube:4.5.6
 
 MAINTAINER Robert Northard, <robert.a.northard>
 


### PR DESCRIPTION
Upgrade will fix at least one issue related to Complexity broken charts.

They also change version of Java ( java:openjdk-8u45-jre ) and added security checks.

I checked on latest version of ADOP, everything looks working:

![screenshot 2016-03-25 17 10 43](https://cloud.githubusercontent.com/assets/380055/14047035/fc8c0d32-f2ad-11e5-9503-37d554ba92fc.png)
