### PR TITLE
Add  core java blueprint plugins to adop-sonar

### DIFF
--- a/resources/plugins.txt
+++ b/resources/plugins.txt
@@ -4,3 +4,16 @@ https://sonarsource.bintray.com/Distribution/sonar-java-plugin/sonar-java-plugin
 http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/sonar-ldap-plugin/1.4/sonar-ldap-plugin-1.4.jar
 http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/sonar-build-breaker-plugin/1.1/sonar-build-breaker-plugin-1.1.jar
 http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/scm-activity/sonar-scm-activity-plugin/1.8/sonar-scm-activity-plugin-1.8.jar
+http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/java/sonar-checkstyle-plugin/2.3/sonar-checkstyle-plugin-2.3.jar
+http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/css/sonar-css-plugin/1.2/sonar-css-plugin-1.2.jar
+http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/jmeter/sonar-jmeter-plugin/0.3/sonar-jmeter-plugin-0.3.jar
+http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/sonar-motion-chart-plugin/1.7/sonar-motion-chart-plugin-1.7.jar
+http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/sonar-pitest-plugin/0.6/sonar-pitest-plugin-0.6.jar
+http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/java/sonar-pmd-plugin/2.4.1/sonar-pmd-plugin-2.4.1.jar
+http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/sonar-scm-stats-plugin/0.3.1/sonar-scm-stats-plugin-0.3.1.jar
+http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/sonar-timeline-plugin/1.4/sonar-timeline-plugin-1.4.jar
+http://central.maven.org/maven2/org/sonarsource/sonar-web-plugin/sonar-web-plugin/2.4/sonar-web-plugin-2.4.jar
+http://central.maven.org/maven2/org/sonarsource/sonar-xml-plugin/sonar-xml-plugin/1.3/sonar-xml-plugin-1.3.jar
+http://downloads.sonarsource.com/plugins/org/sonarsource/sonar-groovy-plugin/sonar-groovy-plugin/1.2/sonar-groovy-plugin-1.2.jar
+http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/sonar-issues-report-plugin/1.3/sonar-issues-report-plugin-1.3.jar
+http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/sonar-tab-metrics-plugin/1.4.1/sonar-tab-metrics-plugin-1.4.1.jar


### PR DESCRIPTION
See below plugins added:
- sonar-checkstyle-plugin-2.3.jar
- sonar-css-plugin-1.2.jar
- sonar-jmeter-plugin-0.3.jar
- sonar-motion-chart-plugin-1.7.jar
- sonar-pitest-plugin-0.6.jar
- sonar-pmd-plugin-2.4.1.jar
- sonar-scm-stats-plugin-0.3.1.jar
- sonar-timeline-plugin-1.4.jar
- sonar-web-plugin-2.4.jar
- sonar-xml-plugin-1.3.jar
