### PR TITLE
Removing outdated Jmeter plugin

### DIFF
--- a/resources/plugins.txt
+++ b/resources/plugins.txt
@@ -6,7 +6,6 @@ http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/sonar-build-
 http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/scm-activity/sonar-scm-activity-plugin/1.8/sonar-scm-activity-plugin-1.8.jar
 http://sonarsource.bintray.com/Distribution/sonar-checkstyle-plugin/sonar-checkstyle-plugin-2.4.jar
 https://github.com/SonarQubeCommunity/sonar-css/releases/download/2.1/sonar-css-plugin-2.1.jar
-http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/jmeter/sonar-jmeter-plugin/0.3/sonar-jmeter-plugin-0.3.jar
 http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/sonar-motion-chart-plugin/1.7/sonar-motion-chart-plugin-1.7.jar
 http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/sonar-pitest-plugin/0.6/sonar-pitest-plugin-0.6.jar
 http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/java/sonar-pmd-plugin/2.4.1/sonar-pmd-plugin-2.4.1.jar


### PR DESCRIPTION
plugin JMeter v3.0 is outdated for Sonarqube 5.6+ (as shown here: http://www.sonarplugins.com/jmeter), hence causing our Sonar builds to fail