### PR TITLE
Updated Findbugs plugin from 3.3 to 3.4.4

### DIFF
--- a/resources/plugins.txt
+++ b/resources/plugins.txt
@@ -1,5 +1,5 @@
 https://sonarsource.bintray.com/Distribution/sonar-javascript-plugin/sonar-javascript-plugin-2.16.0.2922.jar
-http://sonarsource.bintray.com/Distribution/sonar-findbugs-plugin/sonar-findbugs-plugin-3.3.jar
+https://github.com/SonarQubeCommunity/sonar-findbugs/releases/download/3.4.4/sonar-findbugs-plugin-3.4.4.jar
 https://sonarsource.bintray.com/Distribution/sonar-java-plugin/sonar-java-plugin-4.2.jar
 http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/sonar-ldap-plugin/1.4/sonar-ldap-plugin-1.4.jar
 http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/sonar-build-breaker-plugin/1.1/sonar-build-breaker-plugin-1.1.jar


### PR DESCRIPTION
- Sonar is now using [SonarQubeCommunity Github](https://github.com/SonarQubeCommunity) to host all latest Findbugs release packages (sonarsource.bintray.com is no longer being used).
- Latest version 3.4.4 has many beneficial [bug fixes and improvements](https://github.com/SonarQubeCommunity/sonar-findbugs/releases).