### PR TITLE
Ensure that last line of plugins.txt is downloaded

### DIFF
--- a/resources/plugins.sh
+++ b/resources/plugins.sh
@@ -7,7 +7,7 @@ set -e
 
 mkdir -p ${SONARQUBE_PLUGINS_DIR}
 
-while read plugin; do
+while IFS= read plugin || [[ -n "$plugin" ]]; do
     fullname=$(basename "$plugin")
     extension="${fullname##*.}"
     filename="${fullname%.*}"


### PR DESCRIPTION
When plugins.txt last line is not an "empty"line, the last defined plugin will not be downloaded. A simple bash change can fix this.