### PR TITLE
Updated findbugs version to 3.4.4

### DIFF
--- a/resources/plugins.sh
+++ b/resources/plugins.sh
@@ -11,6 +11,7 @@ while read plugin; do
     fullname=$(basename "$plugin")
     extension="${fullname##*.}"
     filename="${fullname%.*}"
+    [[ -z "$filename" ]] && continue
     echo "Downloading ${fullname}"
     case ${extension} in 
         'jar') curl -s -L -f ${plugin} -o ${SONARQUBE_PLUGINS_DIR}/${fullname}

--- a/resources/plugins.txt
+++ b/resources/plugins.txt
@@ -1,5 +1,4 @@
 https://sonarsource.bintray.com/Distribution/sonar-javascript-plugin/sonar-javascript-plugin-2.16.0.2922.jar
-http://sonarsource.bintray.com/Distribution/sonar-findbugs-plugin/sonar-findbugs-plugin-3.3.jar
 https://sonarsource.bintray.com/Distribution/sonar-java-plugin/sonar-java-plugin-4.2.jar
 http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/sonar-ldap-plugin/1.4/sonar-ldap-plugin-1.4.jar
 http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/sonar-build-breaker-plugin/1.1/sonar-build-breaker-plugin-1.1.jar
@@ -15,4 +14,4 @@ http://sonarsource.bintray.com/Distribution/sonar-xml-plugin/sonar-xml-plugin-1.
 https://sonarsource.bintray.com/Distribution/sonar-groovy-plugin/sonar-groovy-plugin-1.4.jar
 http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/sonar-issues-report-plugin/1.3/sonar-issues-report-plugin-1.3.jar
 http://downloads.sonarsource.com/plugins/org/codehaus/sonar-plugins/sonar-tab-metrics-plugin/1.4.1/sonar-tab-metrics-plugin-1.4.1.jar
-https://github.com/SonarQubeCommunity/sonar-findbugs/releases/download/3.4.3/sonar-findbugs-plugin-3.4.3.jar
+https://github.com/SonarQubeCommunity/sonar-findbugs/releases/download/3.4.4/sonar-findbugs-plugin-3.4.4.jar


### PR DESCRIPTION
Changes included:
- Updated Findbugs plugin from 3.4.3 to 3.4.4. It was done because of the problem described here https://github.com/SonarQubeCommunity/sonar-findbugs/issues/46
- Added check to skip empty lines in plugins.txt

This also includes changes which are done on PR #18 