### PR TITLE
fix opts with whitespace and double quotes and upgrade Sonar version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sonarqube:6.7.2
+FROM sonarqube:7.1
 
 MAINTAINER Robert Northard, <robert.a.northard>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,21 @@ sonar:
    - "9000:9000"
   links: 
    - mysql:mysql
+  container_name: sonar
   environment:
-   - ADOP_LDAP_ENABLED=false
+   - ADOP_LDAP_ENABLED=true
+   - LDAP_USER_REQUEST="(uid={0})"
+   - LDAP_USER_REAL_NAME_ATTRIBUTE=cn
+   - LDAP_USER_EMAIL_ATTRIBUTE=mail
+   - LDAP_GROUP_REQUEST="(&(objectClass=groupOfUniqueNames)(uniqueMember={dn}))"
+   - LDAP_GROUP_ID_ATTRIBUTE=cn
+   - SONARQUBE_WEB_CONTEXT=/
    - SONARQUBE_JDBC_USERNAME=sonar
    - SONARQUBE_JDBC_PASSWORD=sonar
    - SONARQUBE_JDBC_URL=jdbc:mysql://mysql:3306/sonar?useUnicode=true&characterEncoding=utf8&rewriteBatchedStatements=true 
 mysql:
  image: mysql:5.7
+ container_name: mysql
  environment:
   - MYSQL_USER=sonar
   - MYSQL_PASSWORD=sonar

--- a/resources/sonar.sh
+++ b/resources/sonar.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash -x
 # FROM sonarqube
 # COPY resources/plugins.txt ${PLUGINS_DIR}/plugins.txt
 # RUN /usr/local/bin/plugins.sh ${PLUGINS_DIR}/plugins.txt
@@ -35,18 +35,17 @@ if [ "$ADOP_LDAP_ENABLED" = true ]
   then
   SONAR_ARGUMENTS+=" -Dsonar.security.realm=LDAP \
     -Dsonar.security.savePassword=false \
-    -Dldap.url=${LDAP_URL} \
-    -Dldap.bindDn=${LDAP_BIND_DN} \
+    -Dldap.url="${LDAP_URL}" \
+    -Dldap.bindDn="$LDAP_BIND_DN" \
     -Dldap.bindPassword=${LDAP_BIND_PASSWORD} \
     -Dldap.user.baseDn=${LDAP_USER_BASE_DN} \
-    -Dldap.user.request=${LDAP_USER_REQUEST} \
-    -Dldap.user.realNameAttribute=${LDAP_USER_REAL_NAME_ATTRIBUTE} \
-    -Dldap.user.emailAttribute=${LDAP_USER_EMAIL_ATTRIBUTE} \
+    -Dldap.user.request=${LDAP_USER_REQUEST:-"(uid={0})"} \
+    -Dldap.user.realNameAttribute=${LDAP_USER_REAL_NAME_ATTRIBUTE:-"cn"} \
+    -Dldap.user.emailAttribute=${LDAP_USER_EMAIL_ATTRIBUTE:-"mail"} \
     -Dldap.group.baseDn=${LDAP_GROUP_BASE_DN} \
-    -Dldap.group.request=${LDAP_GROUP_REQUEST} \
-    -Dldap.group.idAttribute=${LDAP_GROUP_ID_ATTRIBUTE}"
+    -Dldap.group.request=${LDAP_GROUP_REQUEST:-"(&(objectClass=groupOfUniqueNames)(uniqueMember={dn}))"} \
+    -Dldap.group.idAttribute=${LDAP_GROUP_ID_ATTRIBUTE:-"cn"}"
 fi
-
 if [ "$SONARQUBE_JMX_ENABLED" = true ]
   then
   SONARQUBE_WEB_JVM_OPTS+="-Dcom.sun.management.jmxremote \
@@ -77,4 +76,4 @@ if [ ! -e "/opt/sonarqube/logs/access.log" ]
   ln -s /dev/stdout /opt/sonarqube/logs/access.log
 fi
 # Start SonarQube
-./bin/run.sh ${SONAR_ARGUMENTS}
+/bin/bash -c "./bin/run.sh ${SONAR_ARGUMENTS}"


### PR DESCRIPTION
This fixes the issue https://github.com/Accenture/adop-sonar/issues/15 where the bash arguments with whitespaces and doublequotes are not preserved when passed around to other scripts.  
I had similar issue where I had a white space and `LDAP_BIND_DN` and after looking around, found a fix that worked for me 
https://github.com/jenkinsci/docker/pull/194/files

hope this will fix the issue @zarifsamar is seeing as well

**NOTE**
this PR also takes care of the sonar LDAP argument defaults https://docs.sonarqube.org/display/PLUG/LDAP+Plugin . 
Previously they were being to set to empty if not set, and that was causing unexpected behavior as well. 
The default values of following vars are taken care of in `sonar.sh` now:
```
- ADOP_LDAP_ENABLED=true
- LDAP_USER_REQUEST="(uid={0})"
- LDAP_USER_REAL_NAME_ATTRIBUTE=cn
- LDAP_USER_EMAIL_ATTRIBUTE=mail
- LDAP_GROUP_REQUEST="(&(objectClass=groupOfUniqueNames)(uniqueMember={dn}))"
- LDAP_GROUP_ID_ATTRIBUTE=cn
- SONARQUBE_WEB_CONTEXT=/
- SONARQUBE_JDBC_USERNAME=sonar
- SONARQUBE_JDBC_PASSWORD=sonar
- SONARQUBE_JDBC_URL=jdbc:mysql://mysql:3306/sonar?useUnicode=true&characterEncoding=utf8&rewriteBatchedStatements=true 
```